### PR TITLE
Add support for controlling Microinterver export to Grid Cutoff

### DIFF
--- a/devices/deye-sun-12k-sg04lp3.yaml
+++ b/devices/deye-sun-12k-sg04lp3.yaml
@@ -1436,3 +1436,25 @@ select:
       "22:30": 2230
       "23:00": 2300
       "23:30": 2330
+
+  - platform: modbus_controller
+    use_write_multiple: true
+    modbus_controller_id: ${modbus_controller_id}
+    name: "sun12k-Combined Mi. Export to Grid Cutoff"
+    address: 178
+    value_type: U_WORD
+    optionsmap:
+      # Explainer:
+      # Export to Grid Cutoff Disable, Gen Peak Shaving Disable, Grid Peak Shaving Enable, On Grid Always On Disable, External Relay Disable, Loss of lithium battery report fault Enable
+      # 60090 in bits: 1110101010111010, and in bytes: 11101010, 10111010
+      # The bytes are swapped, so 1110101010111010 becomes 1010111010101011, and matches the manual
+      # 11: Export to Grid Cutoff Disable
+      # 10: Gen Peak Shaving Disable
+      # 10: Grid Peak Shaving Enable
+      # 10: On Grid Always On Disable
+      # 10: External Relay Disable
+      # 11: Loss of lithium battery report fault Enable
+      "Mode 1": 60090 # 1110101010111010: Export to Grid Cutoff Disable, Gen Peak Shaving Disable, Grid Peak Shaving Enable, On Grid Always On Disable, External Relay Disable, Loss of lithium battery report fault Enable
+      "Mode 2": 60091 # 1110101010111011: Export to Grid Cutoff Enable, Gen Peak Shaving Disable, Grid Peak Shaving Enable, On Grid Always On Disable, External Relay Disable, Loss of lithium battery report fault Enable
+      "Mode 3": 60074 # 1110101010101010: Export to Grid Cutoff Disable, Gen Peak Shaving Disable, Grid Peak Shaving Disable, On Grid Always On Disable, External Relay Disable, Loss of lithium battery report fault Enable
+      "Mode 4": 60075 # 1110101010101011: Export to Grid Cutoff Enable, Gen Peak Shaving Disable, Grid Peak Shaving Disable, On Grid Always On Disable, External Relay Disable, Loss of lithium battery report fault Enable


### PR DESCRIPTION
Hi, 

Also submitted here, but as I could see that you've requested other people to submit PR's in your repo, here's the same, as submitted in: https://github.com/klatremis/esphome-for-deye/pull/39

I've added support for things located at address 178.

We've tested it on a inverter, and things works as expected.

It's clearly not the most flexible way, but I've added the modes, I guess most users would use.

It's almost 100% sure that it's possible to do this in another way with ESPHome, but as I've not used ESPHome to work with byte-array manipulation on basis of a user selection, this was the easiest way to get things working. I mean; you could make some template logics and get things to work, but, I didn't really want to spend that time, just for that.

So, here's how to write to address 178, and more details about how to control the read of the bits (options) on that modbus address.

Have a good one 😄 !